### PR TITLE
Jiyeon/auth

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,29 @@
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import Signin from './pages/Signin';
+import Signup from './pages/Signup';
+import TodoList from './pages/TodoList';
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Signup />,
+  },
+  {
+    path: '/signup',
+    element: <Signup />,
+  },
+  {
+    path: '/signin',
+    element: <Signin />,
+  },
+  {
+    path: '/todo',
+    element: <TodoList />,
+  },
+]);
+
 function App() {
-  return <div>App</div>;
+  return <RouterProvider router={router} />;
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import ProtectedRoute from './pages/ProtectAuth';
 import Signin from './pages/Signin';
 import Signup from './pages/Signup';
 import TodoList from './pages/TodoList';
@@ -6,19 +7,35 @@ import TodoList from './pages/TodoList';
 const router = createBrowserRouter([
   {
     path: '/',
-    element: <Signup />,
+    element: (
+      <ProtectedRoute isNeeded={false} to="/todo">
+        <Signup />
+      </ProtectedRoute>
+    ),
   },
   {
     path: '/signup',
-    element: <Signup />,
+    element: (
+      <ProtectedRoute isNeeded={false} to="/todo">
+        <Signup />
+      </ProtectedRoute>
+    ),
   },
   {
     path: '/signin',
-    element: <Signin />,
+    element: (
+      <ProtectedRoute isNeeded={false} to="/todo">
+        <Signin />
+      </ProtectedRoute>
+    ),
   },
   {
     path: '/todo',
-    element: <TodoList />,
+    element: (
+      <ProtectedRoute isNeeded={true} to="/signin">
+        <TodoList />
+      </ProtectedRoute>
+    ),
   },
 ]);
 

--- a/src/api/authClient.ts
+++ b/src/api/authClient.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import { FormType } from '../components/Form';
+
+export default class AuthClient {
+  private httpClient = axios.create({
+    baseURL: 'https://www.pre-onboarding-selection-task.shop/',
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  async signup(params: FormType) {
+    return this.httpClient.post('auth/signup', params);
+  }
+
+  async signin(params: FormType) {
+    return this.httpClient.post('auth/signin', params);
+  }
+}

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import auth from '../utils/auth';
+
+export type FormType = {
+  [index: string]: string;
+  email: string;
+  password: string;
+};
+
+type Props = {
+  page: string;
+};
+
+export default function Form({ page }: Props) {
+  const [form, setForm] = useState<FormType>(initialForm);
+  const isAvailable = form.email.includes('@') && form.password.length >= 8;
+  const navigate = useNavigate();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    auth(form, page).then((res) => {
+      if (page === 'signup') {
+        res && navigate('/signin');
+      }
+      if (page === 'signin') {
+        res && navigate('/todo');
+      }
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {inputs.map((item, idx) => (
+        <input
+          key={idx}
+          data-testid={`${item}-input`}
+          name={item}
+          type={item}
+          placeholder={item}
+          onChange={handleChange}
+          value={form[item]}
+        />
+      ))}
+      <button data-testid={`${page}-button`} disabled={!isAvailable}>
+        {page}
+      </button>
+    </form>
+  );
+}
+
+const initialForm = { email: '', password: '' };
+const inputs = ['email', 'password'];

--- a/src/pages/ProtectAuth.tsx
+++ b/src/pages/ProtectAuth.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
+type Props = {
+  children: React.ReactNode;
+  isNeeded: boolean;
+  to: string;
+};
+
+export default function ProtectedRoute({ children, isNeeded, to }: Props) {
+  const isLoggedIn = localStorage.getItem('JWT');
+
+  if (isNeeded ? !isLoggedIn : isLoggedIn) return <Navigate to={to} replace={true} />;
+  return <>{children}</>;
+}

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -1,0 +1,5 @@
+import Form from '../components/Form';
+
+export default function Signin() {
+  return <Form page="signin" />;
+}

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,0 +1,5 @@
+import Form from '../components/Form';
+
+export default function Signup() {
+  return <Form page="signup" />;
+}

--- a/src/pages/TodoList.tsx
+++ b/src/pages/TodoList.tsx
@@ -1,0 +1,3 @@
+export default function TodoList() {
+  return <div>TodoList</div>;
+}

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,17 @@
+import AuthClient from '../api/authClient';
+import { FormType } from '../components/Form';
+
+export default async function auth(form: FormType, type: string) {
+  const auth = new AuthClient();
+
+  if (type === 'signup') {
+    return await auth.signup(form).catch(() => alert('이미 존재하는 아이디입니다.'));
+  }
+  if (type === 'signin') {
+    return await auth.signin(form).then((res) => {
+      const JWT = res.data.access_token;
+      localStorage.setItem('JWT', JWT);
+      return '통신 성공!';
+    });
+  }
+}


### PR DESCRIPTION
## 구현 내용
### 1. signin & signup
- Form 컴포넌트로 중복 코드 방지
- 로그인 회원가입
 a. authClient : api 명세 
 b. auth: 통신 로직
** UI와 함수로직은 분리, api는 캡슐화**

### 2. redirect
- app 파일 내에서 각각의 파일을 ProtectedRoute로 감싸도록 함.
- 각각의 파일은 login했는지 신경쓸 필요없이 하나의 컴포넌트가 변경해줌.

### 성장포인트
- TypeScript에서는 IndexSignature를 그냥 사용할 수 없다.
```ts
type = {
  [index: string]: string
}
```