### PR TITLE
Jihyun/feat auth

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,23 @@
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+
+/** pages */
+import NotFound from './pages/NotFound';
+import SignIn from './pages/SignIn';
+import SignUp from './pages/SignUp';
+import Todo from './pages/Todo';
+
 function App() {
-  return <div>App</div>;
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="*" element={<NotFound />} />
+        <Route path="/" element={<Navigate replace to="/signin" />} />
+        <Route path="/signup" element={<SignUp />} />
+        <Route path="/signin" element={<SignIn />} />
+        <Route path="/todo" element={<Todo />} />
+      </Routes>
+    </BrowserRouter>
+  );
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import NotFound from './pages/NotFound';
 import SignIn from './pages/SignIn';
 import SignUp from './pages/SignUp';
 import Todo from './pages/Todo';
+import PrivateRoute from './components/PrivateRoute';
 
 function App() {
   return (
@@ -12,9 +13,15 @@ function App() {
       <Routes>
         <Route path="*" element={<NotFound />} />
         <Route path="/" element={<Navigate replace to="/signin" />} />
-        <Route path="/signup" element={<SignUp />} />
-        <Route path="/signin" element={<SignIn />} />
-        <Route path="/todo" element={<Todo />} />
+        <Route element={<PrivateRoute authRequire={false} />}>
+          <Route path="/signup" element={<SignUp />} />
+        </Route>
+        <Route element={<PrivateRoute authRequire={false} />}>
+          <Route path="/signin" element={<SignIn />} />
+        </Route>
+        <Route element={<PrivateRoute authRequire={true} />}>
+          <Route path="/todo" element={<Todo />} />
+        </Route>
       </Routes>
     </BrowserRouter>
   );

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,27 @@
+/**
+ * 인증 관련 API 요청 및 후처리 로직을 정의하는 곳
+ * 1. signUpRequest - 회원가입 요청
+ * 2. signInRequest - 로그인 요청
+ */
+
+import axios from 'axios';
+import { FormType } from '../components/Form';
+
+export default class Axios {
+  private useAxios = axios.create({
+    baseURL: 'https://www.pre-onboarding-selection-task.shop/',
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  async signUpRequest(formData: FormType) {
+    return await this.useAxios.post('auth/signup', formData).catch((error) => {
+      alert(error.response.data.message);
+    });
+  }
+
+  async signInRequest(formData: FormType) {
+    return await this.useAxios.post('auth/signin', formData).catch((error) => {
+      alert(error.response.data.message);
+    });
+  }
+}

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -1,0 +1,95 @@
+/**
+ * 회원가입 및 로그인 화면에 사용할 공통 입력 폼 컴포넌트
+ */
+
+import React, { useState, useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import Axios from '../api/auth';
+
+export type FormType = {
+  email: string;
+  password: string;
+};
+
+function Form() {
+  const authRequest = new Axios();
+  const navigate = useNavigate();
+
+  // 현재 url 위치를 파악 (/signin, /signup)
+  const location = useLocation();
+  const [currentLocation, setCurrentLocation] = useState<string>('');
+
+  useEffect(() => {
+    setCurrentLocation(location.pathname);
+  }, [location]);
+
+  // 사용자의 이메일 및 패스워드 상태
+  const [email, setEmail] = useState<FormType['email']>('');
+  const [password, setPassword] = useState<FormType['password']>('');
+
+  // 사용자의 이메일 및 패스워드 상태 변경
+  const handleEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(e.target.value);
+  };
+
+  const handlePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+  };
+
+  // 이메일 및 패스워드 데이터 전송
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (currentLocation === '/signup') {
+      authRequest.signUpRequest({ email, password }).then((res) => {
+        if (res) navigate('/signin');
+      });
+    }
+
+    if (currentLocation === '/signin') {
+      authRequest.signInRequest({ email, password }).then((res) => {
+        if (res) {
+          localStorage.setItem('access_token', res.data.access_token);
+          navigate('/todo');
+        }
+      });
+    }
+  };
+
+  // 이메일 및 패스워드의 입력 검증
+  const isValidated = email.includes('@') && password.length >= 8;
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        data-testid={'email-input'}
+        name={'email'}
+        type={'email'}
+        placeholder={'이메일'}
+        onChange={handleEmail}
+        value={email}
+      />
+      <input
+        data-testid={'password-input'}
+        name={'password'}
+        type={'password'}
+        placeholder={'비밀번호'}
+        onChange={handlePassword}
+        value={password}
+      />
+      {currentLocation === '/signin' ? (
+        <button data-testid={`${currentLocation}-button`} disabled={!isValidated}>
+          로그인
+        </button>
+      ) : currentLocation === '/signup' ? (
+        <button data-testid={`${currentLocation}-button`} disabled={!isValidated}>
+          회원가입
+        </button>
+      ) : (
+        ''
+      )}
+    </form>
+  );
+}
+
+export default Form;

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -1,0 +1,23 @@
+/**
+ * 로그인 여부에 따른 페이지 리다이렉트를 도와주는 컴포넌트
+ */
+
+import { ReactElement } from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+
+interface PrivateRouteProps {
+  children?: ReactElement;
+  authRequire: boolean;
+}
+
+export default function PrivateRoute({ authRequire }: PrivateRouteProps): React.ReactElement | null {
+  const isAuthenticated = localStorage.getItem('access_token');
+
+  if (authRequire) {
+    // 인증이 반드시 필요한 페이지 (authRequire={true})
+    return isAuthenticated === null ? <Navigate to="/signin" /> : <Outlet />;
+  } else {
+    // 인증이 반드시 필요 없는 페이지 (authRequire={false})
+    return isAuthenticated === null ? <Outlet /> : <Navigate to="/todo" />;
+  }
+}

--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -1,0 +1,9 @@
+/**
+ * 존재하지 않는 페이지 컴포넌트
+ */
+
+function NotFound() {
+  return <div>NotFound</div>;
+}
+
+export default NotFound;

--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -1,0 +1,11 @@
+/**
+ * 로그인 컴포넌트
+ */
+
+import Form from '../../components/Form';
+
+function SignIn() {
+  return <Form />;
+}
+
+export default SignIn;

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -1,0 +1,11 @@
+/**
+ * 회원가입 컴포넌트
+ */
+
+import Form from '../../components/Form';
+
+function SignUp() {
+  return <Form />;
+}
+
+export default SignUp;

--- a/src/pages/Todo/index.tsx
+++ b/src/pages/Todo/index.tsx
@@ -1,0 +1,9 @@
+/**
+ * 투두 리스트 컴포넌트
+ */
+
+function Todo() {
+  return <div>Todo</div>;
+}
+
+export default Todo;


### PR DESCRIPTION
## 구현 내용

### 1. 회원가입, 로그인 기능
- 공통 Form 컴포넌트 사용
- useLocation을 이용해 url 검사 후 적절한 api 요청
- /api/auth.ts: Auth api 캡슐화 및 인증 관련 http 통신 로직 작성

### 2. 로그인(토큰) 여부에 따른 리다이렉트 기능
- PrivateRoute 컴포넌트를 활용해 각 페이지 컴포넌트를 감싸도록 함
- 인증이 반드시 필요한 페이지는 authentication={true}를 넘겨주어 토큰 존재 여부에 따라 적절한 페이지를 렌더링
