### PR TITLE
feat : 원티드 프리온보딩 인턴 1주차 미션 - Auth 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
+import { Routes } from './pages/Routes';
+
 function App() {
-  return <div>App</div>;
+  return <Routes />;
 }
 
 export default App;

--- a/src/apis/config.ts
+++ b/src/apis/config.ts
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+const BASE_URL = `https://www.pre-onboarding-selection-task.shop`;
+
+axios.defaults.baseURL = BASE_URL;

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,0 +1,7 @@
+export * from './sign';
+
+export type ErrorResponse = {
+  statusCode: number;
+  message: string;
+  error?: string;
+};

--- a/src/apis/sign.ts
+++ b/src/apis/sign.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+export async function signup(email: string, password: string): Promise<null> {
+  const response = await axios.post(`/auth/signup`, { email, password });
+  return response.data;
+}
+
+export async function signin(email: string, password: string): Promise<SigninBody> {
+  const response = await axios.post<SigninBody>(`/auth/signin`, { email, password });
+  return response.data;
+}
+type SigninBody = {
+  access_token: string;
+};

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useAuth';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useAuth';
+export * from './useSign';

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,15 @@
+import { getItem, STORAGE_KEY } from '../utils';
+
+/**
+ * @desc 로그인 여부를 파악하는 hooks
+ * @returns
+ * - isLogin: 로그인 여부
+ * - token: 로그인시 jwt accessToken
+ */
+export function useAuth() {
+  const token = getItem(STORAGE_KEY.AUTH_KEY);
+  return {
+    isLogin: !!token,
+    token: token,
+  };
+}

--- a/src/hooks/useSign.ts
+++ b/src/hooks/useSign.ts
@@ -1,0 +1,28 @@
+import { ChangeEvent, useState } from 'react';
+
+export function useSign() {
+  const [value, setValue] = useState({
+    email: '',
+    password: '',
+  });
+
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const name = event.currentTarget.name;
+    const value = event.target.value;
+
+    setValue((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const email = value.email;
+  const password = value.password;
+  const isValid = checkValid(email, password);
+
+  return { email, password, isValid, onChange };
+}
+
+function checkValid(email: string, password: string) {
+  return !(!email.includes('@') || password.length < 8);
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter as Router } from 'react-router-dom';
+
+import './apis/config';
+
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <Router>
+      <App />
+    </Router>
   </React.StrictMode>,
 );

--- a/src/pages/AuthRedirect.tsx
+++ b/src/pages/AuthRedirect.tsx
@@ -9,5 +9,5 @@ type AuthRedirectProps = {
 
 export function AuthRedirect({ redirectPath }: AuthRedirectProps) {
   const { isLogin } = useAuth();
-  return isLogin ? <Navigate to={redirectPath} /> : <Outlet />;
+  return isLogin ? <Navigate to={redirectPath} replace /> : <Outlet />;
 }

--- a/src/pages/AuthRedirect.tsx
+++ b/src/pages/AuthRedirect.tsx
@@ -1,0 +1,13 @@
+import { Navigate, Outlet } from 'react-router-dom';
+
+import { useAuth } from '../hooks';
+import { RoutePath } from './Routes';
+
+type AuthRedirectProps = {
+  redirectPath: RoutePath;
+};
+
+export function AuthRedirect({ redirectPath }: AuthRedirectProps) {
+  const { isLogin } = useAuth();
+  return isLogin ? <Navigate to={redirectPath} /> : <Outlet />;
+}

--- a/src/pages/PrivateRoutes.tsx
+++ b/src/pages/PrivateRoutes.tsx
@@ -1,0 +1,13 @@
+import { Navigate, Outlet } from 'react-router-dom';
+
+import { useAuth } from '../hooks';
+import { RoutePath } from './Routes';
+
+type PrivateRoutesProps = {
+  redirectPath: RoutePath;
+};
+
+export function PrivateRoutes({ redirectPath }: PrivateRoutesProps) {
+  const { isLogin } = useAuth();
+  return isLogin ? <Outlet /> : <Navigate to={redirectPath} />;
+}

--- a/src/pages/PrivateRoutes.tsx
+++ b/src/pages/PrivateRoutes.tsx
@@ -9,5 +9,5 @@ type PrivateRoutesProps = {
 
 export function PrivateRoutes({ redirectPath }: PrivateRoutesProps) {
   const { isLogin } = useAuth();
-  return isLogin ? <Outlet /> : <Navigate to={redirectPath} />;
+  return isLogin ? <Outlet /> : <Navigate to={redirectPath} replace />;
 }

--- a/src/pages/Routes.tsx
+++ b/src/pages/Routes.tsx
@@ -1,0 +1,12 @@
+import { Routes as ReactRouterRoutes, Route } from 'react-router-dom';
+
+export const Routes = () => {
+  return (
+    <ReactRouterRoutes>
+      <Route path="/signup" element={<div>Signup</div>} />
+      <Route path="/signin" element={<div>Signin</div>} />
+      <Route path="/" element={<div>홈</div>} />
+      <Route path="*" element={<div>Not Found Page</div>} />
+    </ReactRouterRoutes>
+  );
+};

--- a/src/pages/Routes.tsx
+++ b/src/pages/Routes.tsx
@@ -1,9 +1,11 @@
 import { Routes as ReactRouterRoutes, Route } from 'react-router-dom';
 
+import { SignupPage } from './SignupPage';
+
 export const Routes = () => {
   return (
     <ReactRouterRoutes>
-      <Route path="/signup" element={<div>Signup</div>} />
+      <Route path="/signup" element={<SignupPage />} />
       <Route path="/signin" element={<div>Signin</div>} />
       <Route path="/" element={<div>홈</div>} />
       <Route path="*" element={<div>Not Found Page</div>} />

--- a/src/pages/Routes.tsx
+++ b/src/pages/Routes.tsx
@@ -1,4 +1,7 @@
-import { Routes as ReactRouterRoutes, Route } from 'react-router-dom';
+import { Routes as ReactRouterRoutes, Route, Navigate } from 'react-router-dom';
+
+import { PrivateRoutes } from './PrivateRoutes';
+import { AuthRedirect } from './AuthRedirect';
 
 import { SignupPage } from './SignupPage';
 import { SigninPage } from './SigninPage';
@@ -6,10 +9,20 @@ import { SigninPage } from './SigninPage';
 export const Routes = () => {
   return (
     <ReactRouterRoutes>
-      <Route path="/signup" element={<SignupPage />} />
-      <Route path="/signin" element={<SigninPage />} />
-      <Route path="/" element={<div>홈</div>} />
+      {/*  GYU-TODO: 가독성이 안좋아 보임 */}
+      <Route element={<AuthRedirect redirectPath="/todo" />}>
+        <Route path="/signup" element={<SignupPage />} />
+        <Route path="/signin" element={<SigninPage />} />
+      </Route>
+
+      <Route element={<PrivateRoutes redirectPath="/signin" />}>
+        <Route path="/todo" element={<div>TODO</div>} />
+      </Route>
+
+      <Route path="/" element={<Navigate to="/todo" />} />
       <Route path="*" element={<div>Not Found Page</div>} />
     </ReactRouterRoutes>
   );
 };
+
+export type RoutePath = '/signup' | '/signin' | '/todo';

--- a/src/pages/Routes.tsx
+++ b/src/pages/Routes.tsx
@@ -1,12 +1,13 @@
 import { Routes as ReactRouterRoutes, Route } from 'react-router-dom';
 
 import { SignupPage } from './SignupPage';
+import { SigninPage } from './SigninPage';
 
 export const Routes = () => {
   return (
     <ReactRouterRoutes>
       <Route path="/signup" element={<SignupPage />} />
-      <Route path="/signin" element={<div>Signin</div>} />
+      <Route path="/signin" element={<SigninPage />} />
       <Route path="/" element={<div>홈</div>} />
       <Route path="*" element={<div>Not Found Page</div>} />
     </ReactRouterRoutes>

--- a/src/pages/Routes.tsx
+++ b/src/pages/Routes.tsx
@@ -19,7 +19,7 @@ export const Routes = () => {
         <Route path="/todo" element={<div>TODO</div>} />
       </Route>
 
-      <Route path="/" element={<Navigate to="/todo" />} />
+      <Route path="/" element={<Navigate to="/todo" replace />} />
       <Route path="*" element={<div>Not Found Page</div>} />
     </ReactRouterRoutes>
   );

--- a/src/pages/SigninPage.tsx
+++ b/src/pages/SigninPage.tsx
@@ -1,0 +1,50 @@
+import { FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AxiosError } from 'axios';
+
+import { useSign } from '../hooks/useSign';
+import { ErrorResponse, signin } from '../apis';
+import { STORAGE_KEY, saveItem } from '../utils';
+
+export function SigninPage() {
+  const { email, password, isValid, onChange } = useSign();
+  const navigate = useNavigate();
+
+  const handleSingin = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    try {
+      const data = await signin(email, password);
+      saveItem(STORAGE_KEY.AUTH_KEY, data.access_token);
+      navigate('/todo');
+    } catch (err) {
+      const error = err as AxiosError<ErrorResponse>;
+      if (error.response) {
+        alert(error.response.data.message);
+      }
+    }
+  };
+
+  return (
+    <form onSubmit={handleSingin}>
+      <input
+        type="email"
+        name="email"
+        data-testid="email-input"
+        placeholder="email"
+        value={email}
+        onChange={onChange}
+      />
+      <input
+        type="password"
+        name="password"
+        data-testid="password-input"
+        placeholder="password"
+        value={password}
+        onChange={onChange}
+      />
+      <button type="submit" data-testid="signin-button" disabled={!isValid}>
+        로그인
+      </button>
+    </form>
+  );
+}

--- a/src/pages/SigninPage.tsx
+++ b/src/pages/SigninPage.tsx
@@ -33,6 +33,7 @@ export function SigninPage() {
         placeholder="email"
         value={email}
         onChange={onChange}
+        autoFocus
       />
       <input
         type="password"

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,0 +1,48 @@
+import { FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AxiosError } from 'axios';
+
+import { useSign } from '../hooks';
+import { ErrorResponse, signup } from '../apis';
+
+export function SignupPage() {
+  const { email, password, isValid, onChange } = useSign();
+  const navigate = useNavigate();
+
+  const handleSignup = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    try {
+      await signup(email, password);
+      navigate('/signin');
+    } catch (err) {
+      const error = err as AxiosError<ErrorResponse>;
+      if (error.response) {
+        alert(error.response.data.message);
+      }
+    }
+  };
+
+  return (
+    <form onSubmit={handleSignup}>
+      <input
+        type="email"
+        name="email"
+        data-testid="email-input"
+        placeholder="email"
+        value={email}
+        onChange={onChange}
+      />
+      <input
+        type="password"
+        name="password"
+        data-testid="password-input"
+        placeholder="password"
+        value={password}
+        onChange={onChange}
+      />
+      <button type="submit" data-testid="signup-button" disabled={!isValid}>
+        회원가입
+      </button>
+    </form>
+  );
+}

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -31,6 +31,7 @@ export function SignupPage() {
         placeholder="email"
         value={email}
         onChange={onChange}
+        autoFocus
       />
       <input
         type="password"

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './storage';

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,11 @@
+export const STORAGE_KEY = {
+  AUTH_KEY: 'WANTED_AUTH',
+} as const;
+
+export function saveItem(key: string, value: string) {
+  localStorage.setItem(key, value);
+}
+
+export function getItem(key: string) {
+  return localStorage.getItem(key);
+}


### PR DESCRIPTION
## 💡 개요
원티드 프리온보딩 인턴 1주차 미션 중의 Auth 와 관련된 기능 구현

## 📝 작업 내용
- 회원가입 / 로그인 기능 구현
- 로그인 유무를 위한 hook 구현
- 회원가입 / 로그인 기능을 위한 useSign 훅 구현
- 라우팅 
- 비로그인시 Signin 으로 리다이렉트 하는 PrivateRoute 구현
   로그인시 Redirect 시키는 AuthRedirect 구현


## 🎖 고려 내용
- 회원가입/로그인 UI 가 현재 같아, 하나의 폼으로 뺄까 했는데 그러기 위해선 부가적인 작업이 필요하고 만약, 변경점이 있을 때 더 복잡해질거 같아 UI 는 같지만 독립적으로 구현하였습니다. (아직도 고민중...)
- 연관 있는 기능은 최대한 비슷한 곳에 작업하도록 하였습니다.
- Routing 처리할 때  로그인 유무에 따른 조건에 따라 Redirect 를 처리했는데 가독성이 좋지 않다고 생각되어(비선언적?) 해당 부분을 어떻게 개선할지 고민중입니다. 