### PR TITLE
Inhu/feat auth

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,17 @@
-function App() {
-  return <div>App</div>;
-}
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import SignInPage from './pages/SignInPage';
+import SignUpPage from './pages/SignUpPage';
+import TodoPage from './pages/TodoPage';
 
-export default App;
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Navigate to="/signin" />} />
+        <Route path="/signin" element={<SignInPage />} />
+        <Route path="/signup" element={<SignUpPage />} />
+        <Route path="/todo" element={<TodoPage />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import PublicAuth from './components/common/PublicAuth';
+import PrivateAuth from './components/common/PrivateAuth';
 import SignInPage from './pages/SignInPage';
 import SignUpPage from './pages/SignUpPage';
 import TodoPage from './pages/TodoPage';
@@ -8,9 +10,9 @@ export default function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Navigate to="/signin" />} />
-        <Route path="/signin" element={<SignInPage />} />
-        <Route path="/signup" element={<SignUpPage />} />
-        <Route path="/todo" element={<TodoPage />} />
+        <Route path="/signin" element={<PublicAuth component={SignInPage} redirectURL="/todo" />} />
+        <Route path="/signup" element={<PublicAuth component={SignUpPage} redirectURL="/todo" />} />
+        <Route path="/todo" element={<PrivateAuth component={TodoPage} redirectURL="/signin" />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -8,3 +8,7 @@ interface UserData {
 export async function signin(data: UserData) {
   return apiInstance.post('/auth/signin', data);
 }
+
+export async function signup(data: UserData) {
+  return apiInstance.post('/auth/signup', data);
+}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,10 @@
+import { apiInstance } from '.';
+
+interface UserData {
+  email: string;
+  password: string;
+}
+
+export async function signin(data: UserData) {
+  return apiInstance.post('/auth/signin', data);
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,8 +1,17 @@
 import axios from 'axios';
+import useToken from '../hooks/useToken';
 
 export const apiInstance = axios.create({
   baseURL: 'https://www.pre-onboarding-selection-task.shop',
   headers: {
     'Content-Type': 'application/json',
   },
+});
+
+apiInstance.interceptors.request.use((config) => {
+  const { token } = useToken();
+
+  if (token) config.headers['Authorization'] = `Bearer ${token}`;
+
+  return config;
 });

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+export const apiInstance = axios.create({
+  baseURL: 'https://www.pre-onboarding-selection-task.shop',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});

--- a/src/components/common/PrivateAuth.tsx
+++ b/src/components/common/PrivateAuth.tsx
@@ -1,0 +1,10 @@
+import { Navigate } from 'react-router-dom';
+import { AuthProps } from './type';
+import useToken from '../../hooks/useToken';
+
+export default function PrivateAuth({ component, redirectURL }: AuthProps) {
+  const { token } = useToken();
+
+  if (!token) return <Navigate to={redirectURL} />;
+  return component();
+}

--- a/src/components/common/PublicAuth.tsx
+++ b/src/components/common/PublicAuth.tsx
@@ -1,0 +1,10 @@
+import { Navigate } from 'react-router-dom';
+import { AuthProps } from './type';
+import useToken from '../../hooks/useToken';
+
+export default function PublicAuth({ component, redirectURL }: AuthProps) {
+  const { token } = useToken();
+
+  if (token) return <Navigate to={redirectURL} />;
+  return component();
+}

--- a/src/components/common/type.ts
+++ b/src/components/common/type.ts
@@ -1,0 +1,6 @@
+import { ReactElement } from 'react';
+
+export interface AuthProps {
+  component: () => ReactElement;
+  redirectURL: string;
+}

--- a/src/components/common/utils.ts
+++ b/src/components/common/utils.ts
@@ -2,7 +2,7 @@ type RegType = 'email' | 'password';
 
 const regs = {
   email: /.@./,
-  password: /.[8,]/,
+  password: /.{8,}/,
 };
 
 export function isValid(type: RegType, value: string) {

--- a/src/components/common/utils.ts
+++ b/src/components/common/utils.ts
@@ -1,0 +1,10 @@
+type RegType = 'email' | 'password';
+
+const regs = {
+  email: /.@./,
+  password: /.[8,]/,
+};
+
+export function isValid(type: RegType, value: string) {
+  return regs[type].test(value);
+}

--- a/src/components/signin/index.tsx
+++ b/src/components/signin/index.tsx
@@ -1,15 +1,18 @@
 import { FormEvent, useEffect, useState } from 'react';
 import { isValid } from '../common/utils';
 import useInputValue from '../../hooks/useInputValue';
+import { signin } from '../../api/auth';
 
 export default function SignInForm() {
   const [email, handleEmailChange] = useInputValue();
   const [password, handlePasswordChange] = useInputValue();
   const [valid, setValid] = useState(false);
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    alert(email + ' ' + password);
+
+    const response = await signin({ email, password });
+    console.log(response.data);
   };
 
   useEffect(() => {

--- a/src/components/signin/index.tsx
+++ b/src/components/signin/index.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useEffect, useState } from 'react';
-import useInputValue from '../../hooks/useInputValue';
 import { isValid } from '../common/utils';
+import useInputValue from '../../hooks/useInputValue';
 
 export default function SignInForm() {
   const [email, handleEmailChange] = useInputValue();

--- a/src/components/signin/index.tsx
+++ b/src/components/signin/index.tsx
@@ -1,12 +1,18 @@
+import { FormEvent } from 'react';
 import useInputValue from '../../hooks/useInputValue';
 
 export default function SignInForm() {
   const [email, handleEmailChange] = useInputValue();
   const [password, handlePasswordChange] = useInputValue();
 
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    alert(email + ' ' + password);
+  };
+
   return (
     <>
-      <form>
+      <form onSubmit={handleSubmit}>
         <input type="email" placeholder="이메일" value={email} onChange={handleEmailChange} />
         <input type="password" placeholder="비밀번호" value={password} onChange={handlePasswordChange} />
         <button type="submit">로그인</button>

--- a/src/components/signin/index.tsx
+++ b/src/components/signin/index.tsx
@@ -1,9 +1,14 @@
+import useInputValue from '../../hooks/useInputValue';
+
 export default function SignInForm() {
+  const [email, handleEmailChange] = useInputValue();
+  const [password, handlePasswordChange] = useInputValue();
+
   return (
     <>
       <form>
-        <input type="email" placeholder="이메일" />
-        <input type="password" placeholder="비밀번호" />
+        <input type="email" placeholder="이메일" value={email} onChange={handleEmailChange} />
+        <input type="password" placeholder="비밀번호" value={password} onChange={handlePasswordChange} />
         <button type="submit">로그인</button>
       </form>
       <div>

--- a/src/components/signin/index.tsx
+++ b/src/components/signin/index.tsx
@@ -2,17 +2,19 @@ import { FormEvent, useEffect, useState } from 'react';
 import { isValid } from '../common/utils';
 import { signin } from '../../api/auth';
 import useInputValue from '../../hooks/useInputValue';
+import useToken from '../../hooks/useToken';
 
 export default function SignInForm() {
+  const [valid, setValid] = useState(false);
   const [email, handleEmailChange] = useInputValue();
   const [password, handlePasswordChange] = useInputValue();
-  const [valid, setValid] = useState(false);
+  const { setToken } = useToken();
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     const response = await signin({ email, password });
-    console.log(response.data);
+    setToken(response.data.access_token);
   };
 
   useEffect(() => {

--- a/src/components/signin/index.tsx
+++ b/src/components/signin/index.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useEffect, useState } from 'react';
 import { isValid } from '../common/utils';
-import useInputValue from '../../hooks/useInputValue';
 import { signin } from '../../api/auth';
+import useInputValue from '../../hooks/useInputValue';
 
 export default function SignInForm() {
   const [email, handleEmailChange] = useInputValue();

--- a/src/components/signin/index.tsx
+++ b/src/components/signin/index.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { isValid } from '../common/utils';
 import { signin } from '../../api/auth';
 import useInputValue from '../../hooks/useInputValue';
@@ -9,12 +10,21 @@ export default function SignInForm() {
   const [email, handleEmailChange] = useInputValue();
   const [password, handlePasswordChange] = useInputValue();
   const { setToken } = useToken();
+  const navigate = useNavigate();
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    const response = await signin({ email, password });
-    setToken(response.data.access_token);
+    try {
+      const response = await signin({ email, password });
+
+      if (response.status === 200) {
+        setToken(response.data.access_token);
+        navigate('/todo');
+      }
+    } catch (err) {
+      alert('아이디나 비밀번호를 확인해주세요.');
+    }
   };
 
   useEffect(() => {

--- a/src/components/signin/index.tsx
+++ b/src/components/signin/index.tsx
@@ -1,21 +1,30 @@
-import { FormEvent } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 import useInputValue from '../../hooks/useInputValue';
+import { isValid } from '../common/utils';
 
 export default function SignInForm() {
   const [email, handleEmailChange] = useInputValue();
   const [password, handlePasswordChange] = useInputValue();
+  const [valid, setValid] = useState(false);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     alert(email + ' ' + password);
   };
 
+  useEffect(() => {
+    const result = isValid('email', email) && isValid('password', password);
+    setValid(result);
+  }, [email, password]);
+
   return (
     <>
       <form onSubmit={handleSubmit}>
         <input type="email" placeholder="이메일" value={email} onChange={handleEmailChange} />
         <input type="password" placeholder="비밀번호" value={password} onChange={handlePasswordChange} />
-        <button type="submit">로그인</button>
+        <button type="submit" disabled={!valid}>
+          로그인
+        </button>
       </form>
       <div>
         <a href="/signup">회원가입</a>

--- a/src/components/signin/index.tsx
+++ b/src/components/signin/index.tsx
@@ -35,9 +35,15 @@ export default function SignInForm() {
   return (
     <>
       <form onSubmit={handleSubmit}>
-        <input type="email" placeholder="이메일" value={email} onChange={handleEmailChange} />
-        <input type="password" placeholder="비밀번호" value={password} onChange={handlePasswordChange} />
-        <button type="submit" disabled={!valid}>
+        <input data-testid="email-input" type="email" placeholder="이메일" value={email} onChange={handleEmailChange} />
+        <input
+          data-testid="password-input"
+          type="password"
+          placeholder="비밀번호"
+          value={password}
+          onChange={handlePasswordChange}
+        />
+        <button data-testid="signin-button" type="submit" disabled={!valid}>
           로그인
         </button>
       </form>

--- a/src/components/signin/index.tsx
+++ b/src/components/signin/index.tsx
@@ -1,0 +1,14 @@
+export default function SignInForm() {
+  return (
+    <>
+      <form>
+        <input type="email" placeholder="이메일" />
+        <input type="password" placeholder="비밀번호" />
+        <button type="submit">로그인</button>
+      </form>
+      <div>
+        <a href="/signup">회원가입</a>
+      </div>
+    </>
+  );
+}

--- a/src/components/signup/index.tsx
+++ b/src/components/signup/index.tsx
@@ -1,0 +1,36 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { isValid } from '../common/utils';
+import { signin } from '../../api/auth';
+import useInputValue from '../../hooks/useInputValue';
+
+export default function SignUpForm() {
+  const [valid, setValid] = useState(false);
+  const [email, handleEmailChange] = useInputValue();
+  const [password, handlePasswordChange] = useInputValue();
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const response = await signin({ email, password });
+  };
+
+  useEffect(() => {
+    const result = isValid('email', email) && isValid('password', password);
+    setValid(result);
+  }, [email, password]);
+
+  return (
+    <>
+      <form onSubmit={handleSubmit}>
+        <input type="email" placeholder="이메일" value={email} onChange={handleEmailChange} />
+        <input type="password" placeholder="비밀번호" value={password} onChange={handlePasswordChange} />
+        <button type="submit" disabled={!valid}>
+          회원가입
+        </button>
+      </form>
+      <div>
+        <a href="/signin">로그인</a>
+      </div>
+    </>
+  );
+}

--- a/src/components/signup/index.tsx
+++ b/src/components/signup/index.tsx
@@ -1,17 +1,28 @@
 import { FormEvent, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { isValid } from '../common/utils';
-import { signin } from '../../api/auth';
+import { signup } from '../../api/auth';
 import useInputValue from '../../hooks/useInputValue';
 
 export default function SignUpForm() {
   const [valid, setValid] = useState(false);
   const [email, handleEmailChange] = useInputValue();
   const [password, handlePasswordChange] = useInputValue();
+  const navigate = useNavigate();
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    const response = await signin({ email, password });
+    try {
+      const response = await signup({ email, password });
+
+      if (response.status === 201) {
+        alert('회원가입이 완료되었습니다!');
+        navigate('/signin');
+      }
+    } catch (err) {
+      alert('회원가입에 실패했습니다. 다시 시도해주세요. ');
+    }
   };
 
   useEffect(() => {

--- a/src/components/signup/index.tsx
+++ b/src/components/signup/index.tsx
@@ -33,9 +33,15 @@ export default function SignUpForm() {
   return (
     <>
       <form onSubmit={handleSubmit}>
-        <input type="email" placeholder="이메일" value={email} onChange={handleEmailChange} />
-        <input type="password" placeholder="비밀번호" value={password} onChange={handlePasswordChange} />
-        <button type="submit" disabled={!valid}>
+        <input data-testid="email-input" type="email" placeholder="이메일" value={email} onChange={handleEmailChange} />
+        <input
+          data-testid="password-input"
+          type="password"
+          placeholder="비밀번호"
+          value={password}
+          onChange={handlePasswordChange}
+        />
+        <button data-testid="signup-button" type="submit" disabled={!valid}>
           회원가입
         </button>
       </form>

--- a/src/hooks/useInputValue.ts
+++ b/src/hooks/useInputValue.ts
@@ -1,0 +1,13 @@
+import { ChangeEvent, useState } from 'react';
+
+export default function useInputValue(
+  initialValue?: string,
+): [value: string, handleValueChange: (event: ChangeEvent<HTMLInputElement>) => void] {
+  const [value, setValue] = useState<string>(initialValue ?? '');
+
+  const handleValueChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.value);
+  };
+
+  return [value, handleValueChange];
+}

--- a/src/hooks/useToken.ts
+++ b/src/hooks/useToken.ts
@@ -1,0 +1,11 @@
+const STORAGE_KEY = 'ACCESS_TOKEN';
+
+export default function useToken() {
+  const token = localStorage.getItem(STORAGE_KEY);
+
+  const setToken = (newToken: string) => {
+    localStorage.setItem(STORAGE_KEY, newToken);
+  };
+
+  return { token, setToken };
+}

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -1,7 +1,10 @@
+import SignInForm from '../components/signin';
+
 export default function SignInPage() {
   return (
     <div>
       <h1>로그인</h1>
+      <SignInForm />
     </div>
   );
 }

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -1,0 +1,7 @@
+export default function SignInPage() {
+  return (
+    <div>
+      <h1>로그인</h1>
+    </div>
+  );
+}

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,7 +1,10 @@
+import SignUpForm from '../components/signup';
+
 export default function SignUpPage() {
   return (
     <div>
       <h1>회원가입</h1>
+      <SignUpForm />
     </div>
   );
 }

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,0 +1,7 @@
+export default function SignUpPage() {
+  return (
+    <div>
+      <h1>회원가입</h1>
+    </div>
+  );
+}

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -1,0 +1,7 @@
+export default function TodoPage() {
+  return (
+    <div>
+      <h1>TODO</h1>
+    </div>
+  );
+}


### PR DESCRIPTION
## 기능
- 로그인, 회원가입
- 입력폼 값 유효성 검사
- 토근 유무에 따라 페이지별 접근 권한 처리

## 구현 사항
- 유효성 검사를 위해 이메일, 비밀번호에 대한 정규식 정의
- `useInputValid`: input 태그에서 사용하는 value와 onChange 핸들러를 반환하는 훅
- `useToken`: 로컬 스토리지에 저장된 access token과 set 함수를 반환하는 훅
- `PrivateAuth`, `PublicAuth`: 접근 권한이 필요한 페이지에 적용하기 위한 컴포넌트