### PR TITLE
feat : 원티드 프리온보딩 인턴 1주차 미션 - Todo 기능 구현

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,5 @@
+export * from './todo';
+
 import axios from 'axios';
 import { useAuth } from '../hooks';
 

--- a/src/api/todo.ts
+++ b/src/api/todo.ts
@@ -1,0 +1,6 @@
+export type Todo = {
+  id: number;
+  todo: string;
+  isCompleted: boolean;
+  userId: number;
+};

--- a/src/api/todo.ts
+++ b/src/api/todo.ts
@@ -1,6 +1,28 @@
+import { apiInstance } from './index';
+
 export type Todo = {
   id: number;
   todo: string;
   isCompleted: boolean;
   userId: number;
 };
+
+export async function createTodo(todo: string): Promise<Todo> {
+  const response = await apiInstance.post('/todos', { todo });
+  return response.data;
+}
+
+export async function getTodos(): Promise<Todo[]> {
+  const response = await apiInstance.get('/todos');
+  return response.data;
+}
+
+// GYU-TODO: 인자 여러개 말고 단순하게 받을 수 있도록 고민하기
+export async function updateTodo(todoId: number, todo: string, isCompleted: boolean): Promise<Todo> {
+  const response = await apiInstance.put(`/todos/${todoId}`, { todo, isCompleted });
+  return response.data;
+}
+
+export function deleteTodo(todoId: number): Promise<null> {
+  return apiInstance.delete(`/todos/${todoId}`);
+}

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -31,6 +31,7 @@ export const AuthForm = ({ testId, title, onSubmit }: AuthFormProps) => {
         value={email}
         onChange={onChange}
         placeholder="example@domain.com"
+        autoFocus
       />
       <label htmlFor="password">Password:</label>
       <Input

--- a/src/components/todo/TodoAdder.tsx
+++ b/src/components/todo/TodoAdder.tsx
@@ -21,7 +21,7 @@ export function TodoAdder() {
 
   return (
     <form onSubmit={handleSubmit}>
-      <input data-testid="new-todo-input" value={todo} onChange={handleChange} />
+      <input data-testid="new-todo-input" value={todo} onChange={handleChange} autoFocus />
       <button type="submit" data-testid="new-todo-add-button">
         추가
       </button>

--- a/src/components/todo/TodoAdder.tsx
+++ b/src/components/todo/TodoAdder.tsx
@@ -1,13 +1,27 @@
 import { ChangeEvent, FormEvent, useState } from 'react';
 
+import { useTodo } from '../../context/todo';
+
 export function TodoAdder() {
+  const { onTodoAdder } = useTodo();
+
+  const [todo, setTodo] = useState('');
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setTodo(event.target.value);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!todo) return;
+
+    onTodoAdder(todo);
+    setTodo('');
+  };
+
   return (
-    <form
-      onSubmit={() => {
-        console.log;
-      }}
-    >
-      <input data-testid="new-todo-input" />
+    <form onSubmit={handleSubmit}>
+      <input data-testid="new-todo-input" value={todo} onChange={handleChange} />
       <button type="submit" data-testid="new-todo-add-button">
         추가
       </button>

--- a/src/components/todo/TodoAdder.tsx
+++ b/src/components/todo/TodoAdder.tsx
@@ -1,12 +1,12 @@
-import { FormEvent } from 'react';
+import { ChangeEvent, FormEvent, useState } from 'react';
 
 export function TodoAdder() {
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-  };
-
   return (
-    <form onSubmit={handleSubmit}>
+    <form
+      onSubmit={() => {
+        console.log;
+      }}
+    >
       <input data-testid="new-todo-input" />
       <button type="submit" data-testid="new-todo-add-button">
         추가

--- a/src/components/todo/TodoAdder.tsx
+++ b/src/components/todo/TodoAdder.tsx
@@ -1,0 +1,16 @@
+import { FormEvent } from 'react';
+
+export function TodoAdder() {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input data-testid="new-todo-input" />
+      <button type="submit" data-testid="new-todo-add-button">
+        추가
+      </button>
+    </form>
+  );
+}

--- a/src/components/todo/TodoItem.tsx
+++ b/src/components/todo/TodoItem.tsx
@@ -1,0 +1,9 @@
+import { Todo } from '../../api/todo';
+
+type TodoItemProps = {
+  todo: Todo;
+};
+
+export function TodoItem({ todo }: TodoItemProps) {
+  return <li>{todo.todo}</li>;
+}

--- a/src/components/todo/TodoItem.tsx
+++ b/src/components/todo/TodoItem.tsx
@@ -1,9 +1,31 @@
-import { Todo } from '../../api/todo';
+import { useState } from 'react';
+
+import { Todo } from '../../api';
+import { TodoItemViewer } from './TodoItemViewer';
+import { TodoItemEditor } from './TodoItemEditor';
+import styled from 'styled-components';
 
 type TodoItemProps = {
   todo: Todo;
 };
 
 export function TodoItem({ todo }: TodoItemProps) {
-  return <li>{todo.todo}</li>;
+  const [viewMode, setViewMode] = useState(true);
+
+  // GYU-TODO: 선언형이면, react-if 패턴이 더 좋을까!?
+  return (
+    <TodoItemWrapper>
+      {viewMode ? (
+        <TodoItemViewer todo={todo} onChangeEditMode={() => setViewMode(false)} />
+      ) : (
+        <TodoItemEditor todo={todo} onChangeViewMode={() => setViewMode(true)} />
+      )}
+    </TodoItemWrapper>
+  );
 }
+
+const TodoItemWrapper = styled.li`
+  list-style: none;
+  display: flex;
+  gap: 0.5rem;
+`;

--- a/src/components/todo/TodoItemEditor.tsx
+++ b/src/components/todo/TodoItemEditor.tsx
@@ -1,0 +1,42 @@
+import { ChangeEvent, FormEvent, useState } from 'react';
+
+import { Todo } from '../../api';
+import { useTodo } from '../../context/todo';
+
+type TodoItemEditorProps = {
+  todo: Todo;
+  onChangeViewMode: () => void;
+};
+export function TodoItemEditor({ todo, onChangeViewMode }: TodoItemEditorProps) {
+  const { onTodoUpdate } = useTodo();
+
+  const [value, setValue] = useState(todo.todo);
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.value);
+  };
+
+  const handleSubmitUpdateTodo = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!value) return;
+
+    const updatedTodo = { ...todo, todo: value };
+    onTodoUpdate(updatedTodo);
+    onChangeViewMode();
+  };
+
+  return (
+    <form onSubmit={handleSubmitUpdateTodo}>
+      <label>
+        <input type="checkbox" checked={todo.isCompleted} readOnly />
+        <input data-testid="modify-input" value={value} onChange={handleChange} />
+      </label>
+      <button type="submit" data-testid="submit-button">
+        제출
+      </button>
+      <button type="button" data-testid="cancel-button" onClick={onChangeViewMode}>
+        취소
+      </button>
+    </form>
+  );
+}

--- a/src/components/todo/TodoItemEditor.tsx
+++ b/src/components/todo/TodoItemEditor.tsx
@@ -29,7 +29,7 @@ export function TodoItemEditor({ todo, onChangeViewMode }: TodoItemEditorProps) 
     <form onSubmit={handleSubmitUpdateTodo}>
       <label>
         <input type="checkbox" checked={todo.isCompleted} readOnly />
-        <input data-testid="modify-input" value={value} onChange={handleChange} />
+        <input data-testid="modify-input" value={value} onChange={handleChange} autoFocus />
       </label>
       <button type="submit" data-testid="submit-button">
         제출

--- a/src/components/todo/TodoItemViewer.tsx
+++ b/src/components/todo/TodoItemViewer.tsx
@@ -1,0 +1,32 @@
+import { ChangeEvent } from 'react';
+
+import { useTodo } from '../../context/todo';
+import { Todo } from '../../api';
+
+type TodoItemViewerProps = {
+  todo: Todo;
+  onChangeEditMode: () => void;
+};
+export function TodoItemViewer({ todo, onChangeEditMode }: TodoItemViewerProps) {
+  const { onTodoUpdate, onTodoDelete } = useTodo();
+
+  const handleChangeItemCompleted = (event: ChangeEvent<HTMLInputElement>) => {
+    const isCompleted = event.target.checked;
+    onTodoUpdate({ ...todo, isCompleted });
+  };
+
+  return (
+    <>
+      <label>
+        <input type="checkbox" checked={todo.isCompleted} onChange={handleChangeItemCompleted} />
+        <span>{todo.todo}</span>
+      </label>
+      <button data-testid="modify-button" onClick={onChangeEditMode}>
+        수정
+      </button>
+      <button data-testid="delete-button" onClick={() => onTodoDelete(todo.id)}>
+        삭제
+      </button>
+    </>
+  );
+}

--- a/src/components/todo/TodoList.tsx
+++ b/src/components/todo/TodoList.tsx
@@ -1,27 +1,9 @@
 import { TodoItem } from './TodoItem';
-import { Todo } from '../../api/todo';
+import { useTodo } from '../../context/todo';
 
-const todos: Todo[] = [
-  {
-    id: 1,
-    todo: 'react',
-    userId: 1,
-    isCompleted: false,
-  },
-  {
-    id: 2,
-    todo: 'typescript',
-    userId: 1,
-    isCompleted: false,
-  },
-  {
-    id: 3,
-    todo: 'nextjs',
-    userId: 1,
-    isCompleted: true,
-  },
-];
 export function TodoList() {
+  const { todos } = useTodo();
+
   return (
     <>
       {todos.map((todo) => (

--- a/src/components/todo/TodoList.tsx
+++ b/src/components/todo/TodoList.tsx
@@ -1,0 +1,32 @@
+import { TodoItem } from './TodoItem';
+import { Todo } from '../../api/todo';
+
+const todos: Todo[] = [
+  {
+    id: 1,
+    todo: 'react',
+    userId: 1,
+    isCompleted: false,
+  },
+  {
+    id: 2,
+    todo: 'typescript',
+    userId: 1,
+    isCompleted: false,
+  },
+  {
+    id: 3,
+    todo: 'nextjs',
+    userId: 1,
+    isCompleted: true,
+  },
+];
+export function TodoList() {
+  return (
+    <>
+      {todos.map((todo) => (
+        <TodoItem key={todo.id} todo={todo} />
+      ))}
+    </>
+  );
+}

--- a/src/components/todo/index.ts
+++ b/src/components/todo/index.ts
@@ -1,0 +1,2 @@
+export * from './TodoAdder';
+export * from './TodoList';

--- a/src/context/todo/TodoContext.tsx
+++ b/src/context/todo/TodoContext.tsx
@@ -1,0 +1,12 @@
+import { createContext } from 'react';
+
+import { Todo } from '../../api';
+
+export const TodoContext = createContext<TodoContextType | null>(null);
+
+type TodoContextType = {
+  todos: Todo[];
+  onTodoAdder: (todo: string) => void;
+  onTodoDelete: (todoId: number) => void;
+  onTodoUpdate: (todo: Todo) => void;
+};

--- a/src/context/todo/TodoProvider.tsx
+++ b/src/context/todo/TodoProvider.tsx
@@ -1,0 +1,31 @@
+import { PropsWithChildren, useEffect, useState } from 'react';
+
+import { TodoContext } from './TodoContext';
+import { createTodo, deleteTodo, getTodos, Todo, updateTodo } from '../../api';
+
+export function TodoProvider({ children }: PropsWithChildren) {
+  const [todos, setTodos] = useState<Todo[]>([]);
+
+  useEffect(() => {
+    getTodos().then(setTodos).catch(console.error);
+  }, []);
+
+  const onTodoAdder = async (todo: string) => {
+    const newTodo = await createTodo(todo);
+    newTodo && setTodos((prev) => prev.concat(newTodo));
+  };
+
+  const onTodoDelete = async (todoId: number) => {
+    await deleteTodo(todoId);
+    setTodos((prev) => prev.filter((todo) => todo.id !== todoId));
+  };
+
+  const onTodoUpdate = async (todo: Todo) => {
+    const updatedTodo = await updateTodo(todo.id, todo.todo, todo.isCompleted);
+    setTodos((prev) => prev.map((todo) => (todo.id === updatedTodo.id ? updatedTodo : todo)));
+  };
+
+  return (
+    <TodoContext.Provider value={{ todos, onTodoAdder, onTodoUpdate, onTodoDelete }}>{children}</TodoContext.Provider>
+  );
+}

--- a/src/context/todo/index.ts
+++ b/src/context/todo/index.ts
@@ -1,0 +1,3 @@
+export * from './TodoContext';
+export * from './TodoProvider';
+export * from './useTodo';

--- a/src/context/todo/useTodo.tsx
+++ b/src/context/todo/useTodo.tsx
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+
+import { TodoContext } from './TodoContext';
+
+export const useTodo = () => {
+  const todoContext = useContext(TodoContext);
+  if (!todoContext) {
+    throw new Error('Could not find TodoContext');
+  }
+  return todoContext;
+};

--- a/src/pages/Routes.tsx
+++ b/src/pages/Routes.tsx
@@ -4,6 +4,7 @@ import { PrivateRoutes } from './PrivateRoutes';
 import { AuthRedirect } from './AuthRedirect';
 import { SigninPage } from './SigninPage';
 import { SignupPage } from './SignupPage';
+import { TodoPage } from './TodoPage';
 
 export const Routes = () => {
   return (
@@ -14,7 +15,7 @@ export const Routes = () => {
       </Route>
 
       <Route element={<PrivateRoutes redirectPath="/signin" />}>
-        <Route path="/todo" element={<div>TODO</div>} />
+        <Route path="/todo" element={<TodoPage />} />
       </Route>
 
       <Route path="/" element={<Navigate to="/todo" replace />} />

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -1,0 +1,10 @@
+import { TodoAdder, TodoList } from '../components/todo';
+
+export function TodoPage() {
+  return (
+    <>
+      <TodoAdder />
+      <TodoList />
+    </>
+  );
+}

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -1,10 +1,11 @@
+import { TodoProvider } from '../context/todo';
 import { TodoAdder, TodoList } from '../components/todo';
 
 export function TodoPage() {
   return (
-    <>
+    <TodoProvider>
       <TodoAdder />
       <TodoList />
-    </>
+    </TodoProvider>
   );
 }


### PR DESCRIPTION
## 💡 개요
원티드 프리온보딩 인턴 1주차 미션 - Todo 기능 구현

## 📝 작업 내용
- TodoList 기능 구현
- UI 와 비즈니스 로직 분리하기 (components / context 로 분리)
- todo api 구현

## 🎖 고려 내용
- signform, todoAdder, todo 수정 모드에서 바로 입력 가능하도록 autoFocus 적용 (UX 개선)
- 각 모듈? 별 책임과 역할로 구현
  - api 는 서버와 통신하기 위한 api 정의
  - context 는 todo 도메인과 관련된 비즈니스 로직 정의 (사용하는 곳에서 이미 정의된 기능 사용)
  - components
    -  `TodoAdder` 는 투두 아이템을 추가하는 책임
    -  `TodoList` 는 서버에서 가져온 todo item 들을 렌더링 하는 역할
    - `TodoItem` 은 투두리스트의 아이템으로, viewMode 여부에 따라 editor 인지 viewer 인지 렌더링, view/edit mode 전환 기능 담당
    - `TodoItemViewer` 은 viewMode 로 렌더링, 수정 모드로 변환, 삭제 기능, 아이템의 completed 수정 기능을 담당
    - `TodoItemEditor` 는 기존 todo 를 수정하는 기능, viewMode 로 전환하는 기능을 담당